### PR TITLE
chore: update wit-bindgen to 0.41.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ crate-type = ["cdylib"]
 
 [dependencies]
 anyhow = "1.0.86"
-wit-bindgen = "0.40.0"
+wit-bindgen = "0.41.0"
 
 [dev-dependencies]
 pretty_assertions = "1.4.1"


### PR DESCRIPTION
### Description of Changes

Just a quick deps update to keep up with the latest toolig.