### PR TITLE
Fix build command to handle hardlink issue on Linux

### DIFF
--- a/data-collection/edgee-component.toml
+++ b/data-collection/edgee-component.toml
@@ -13,7 +13,7 @@ language = "Rust"
 wit-version = "1.0.0"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && mv ./target/wasm32-wasip2/release/example_rust_component.wasm ./component.wasm"
+command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && rm -f ./component.wasm && mv ./target/wasm32-wasip2/release/example_rust_component.wasm ./component.wasm"
 output_path = "component.wasm"
 
 [component.settings.example]

--- a/edge-function/edgee-component.toml
+++ b/edge-function/edgee-component.toml
@@ -13,7 +13,7 @@ language = "Rust"
 wit-version = "1.0.0"
 
 [component.build]
-command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && mv ./target/wasm32-wasip2/release/example_rust_edge_function_component.wasm ./component.wasm"
+command = "cargo build --target wasm32-wasip2 --release --target-dir ./target && rm -f ./component.wasm && mv ./target/wasm32-wasip2/release/example_rust_edge_function_component.wasm ./component.wasm"
 output_path = "component.wasm"
 
 [component.settings.example]


### PR DESCRIPTION
## Summary
- Add `rm -f [output_file]` before `mv`/`cp` operations in build commands
- Prevents "cannot move file to itself" errors on Linux where output WASM file is already a hardlink