### PR TITLE
add unit tests for edge function helpers (75% coverage)

### DIFF
--- a/edge-function/src/helpers/body.rs
+++ b/edge-function/src/helpers/body.rs
@@ -149,3 +149,227 @@ impl<T: Into<Bytes>> IntoBody for Html<T> {
             .or_insert(http::HeaderValue::from_static("text/html; charset=utf-8"));
     }
 }
+
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_bytes_from_data() {
+        let data = Bytes::from("hello");
+        let result = Bytes::from_data(data.clone()).unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_bytes_into_body() {
+        let data = Bytes::from("world");
+        let result = data.clone().into_body().unwrap();
+        assert_eq!(result, data);
+    }
+
+    #[test]
+    fn test_unit_from_data() {
+        let data = Bytes::from("ignored");
+        let result = <()>::from_data(data).unwrap();
+        assert_eq!(result, ());
+    }
+
+    #[test]
+    fn test_unit_into_body() {
+        let result = ().into_body().unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_string_from_data() {
+        let data = Bytes::from("hello world");
+        let result = String::from_data(data).unwrap();
+        assert_eq!(result, "hello world");
+    }
+
+    #[test]
+    fn test_string_into_body() {
+        let s = String::from("abc");
+        let result = s.into_body().unwrap();
+        assert_eq!(result, Bytes::from("abc"));
+    }
+
+    #[test]
+    fn test_option_from_data_some() {
+        let data = Bytes::from("foo");
+        let result: Option<String> = Option::<String>::from_data(data).unwrap();
+        assert_eq!(result, Some("foo".to_string()));
+    }
+
+    #[test]
+    fn test_option_from_data_none() {
+        let data = Bytes::new();
+        let result: Option<String> = Option::<String>::from_data(data).unwrap();
+        assert_eq!(result, None);
+    }
+
+    #[test]
+    fn test_option_into_body_some() {
+        let opt = Some(Bytes::from("bar"));
+        let result = opt.into_body().unwrap();
+        assert_eq!(result, Bytes::from("bar"));
+    }
+
+    #[test]
+    fn test_option_into_body_none() {
+        let opt: Option<Bytes> = None;
+        let result = opt.into_body().unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_json_from_data_and_into_body() {
+        #[derive(serde::Serialize, serde::Deserialize, PartialEq, Debug)]
+        struct Test { a: i32 }
+        let obj = Test { a: 42 };
+        let json_bytes = serde_json::to_vec(&obj).unwrap();
+        let json = Json::<Test>::from_data(Bytes::from(json_bytes)).unwrap();
+        assert_eq!(json.0, obj);
+
+        let body = json.into_body().unwrap();
+        let decoded: Test = serde_json::from_slice(&body).unwrap();
+        assert_eq!(decoded, obj);
+    }
+
+    #[test]
+    fn test_raw_json_into_body() {
+        let raw = RawJson(Bytes::from("{\"x\":1}"));
+        let result = raw.into_body().unwrap();
+        assert_eq!(result, Bytes::from("{\"x\":1}"));
+    }
+
+    #[test]
+    fn test_html_into_body() {
+        let html = Html(Bytes::from("<h1>hi</h1>"));
+        let result = html.into_body().unwrap();
+        assert_eq!(result, Bytes::from("<h1>hi</h1>"));
+    }
+
+    #[test]
+    fn test_json_extend_response_parts_sets_content_type() {
+        #[derive(serde::Serialize)]
+        struct Dummy { x: i32 }
+        let json = Json(Dummy { x: 1 });
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        json.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_html_extend_response_parts_sets_content_type() {
+        let html = Html(Bytes::from("<p>test</p>"));
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        html.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        assert_eq!(content_type, "text/html; charset=utf-8");
+    }
+
+    #[test]
+    fn test_raw_json_extend_response_parts_sets_content_type() {
+        let raw = RawJson(Bytes::from("{}"));
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        raw.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_option_extend_response_parts_some() {
+        #[derive(serde::Serialize)]
+        struct Dummy { x: i32 }
+        let json = Some(Json(Dummy { x: 2 }));
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        json.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_option_extend_response_parts_none() {
+        let json: Option<Json<()>> = None;
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        json.extend_response_parts(&mut parts);
+        assert!(parts.headers.get(http::header::CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn test_bytes_extend_response_parts_does_nothing() {
+        let bytes = Bytes::from("data");
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        bytes.extend_response_parts(&mut parts);
+        assert!(parts.headers.get(http::header::CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn test_unit_extend_response_parts_does_nothing() {
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        ().extend_response_parts(&mut parts);
+        assert!(parts.headers.get(http::header::CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn test_string_extend_response_parts_does_nothing() {
+        let s = String::from("abc");
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        s.extend_response_parts(&mut parts);
+        assert!(parts.headers.get(http::header::CONTENT_TYPE).is_none());
+    }
+
+    #[test]
+    fn test_json_extend_response_parts_doesnt_overwrite_existing_content_type() {
+        #[derive(serde::Serialize)]
+        struct Dummy { x: i32 }
+        let json = Json(Dummy { x: 1 });
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        parts.headers.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("text/plain"));
+        json.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        // Should remain as "text/plain" since or_insert does not overwrite
+        assert_eq!(content_type, "text/plain");
+    }
+
+    #[test]
+    fn test_html_extend_response_parts_doesnt_overwrites_existing_content_type() {
+        let html = Html(Bytes::from("<p>test</p>"));
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        parts.headers.insert(http::header::CONTENT_TYPE, http::HeaderValue::from_static("application/json"));
+        html.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        // Should remain as "application/json" since or_insert does not overwrite
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_json_extend_response_parts_adds_content_type() {
+        #[derive(serde::Serialize)]
+        struct Dummy { x: i32 }
+        let json = Json(Dummy { x: 1 });
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        json.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        // Should remain as "text/plain" since or_insert does not overwrite
+        assert_eq!(content_type, "application/json");
+    }
+
+    #[test]
+    fn test_html_extend_response_parts_adds_content_type() {
+        let html = Html(Bytes::from("<p>test</p>"));
+        let (mut parts, _) = http::response::Response::new("ok").into_parts();
+        html.extend_response_parts(&mut parts);
+        let content_type = parts.headers.get(http::header::CONTENT_TYPE).unwrap();
+        // Should remain as "application/json" since or_insert does not overwrite
+        assert_eq!(content_type, "text/html; charset=utf-8");
+    }
+
+
+
+}

--- a/edge-function/src/helpers/mod.rs
+++ b/edge-function/src/helpers/mod.rs
@@ -63,3 +63,46 @@ fn json_error_response(status_code: StatusCode, err: anyhow::Error) -> Response<
         )
         .unwrap()
 }
+
+#[cfg(test)]
+mod tests {
+
+    use super::*;
+
+    #[test]
+    fn test_json_error_response_bad_request() {
+        let err = anyhow::anyhow!("invalid input");
+        let response = json_error_response(StatusCode::BAD_REQUEST, err);
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+
+        let body_bytes = response.body();
+        let body_str = std::str::from_utf8(body_bytes).unwrap();
+        assert!(body_str.contains("\"error\":\"invalid input\""));
+    }
+
+    #[test]
+    fn test_json_error_response_internal_server_error() {
+        let err = anyhow::anyhow!("something went wrong");
+        let response = json_error_response(StatusCode::INTERNAL_SERVER_ERROR, err);
+
+        assert_eq!(response.status(), StatusCode::INTERNAL_SERVER_ERROR);
+
+        let body_bytes = response.body();
+        let body_str = std::str::from_utf8(body_bytes).unwrap();
+        assert!(body_str.contains("\"error\":\"something went wrong\""));
+    }
+
+    #[test]
+    fn test_json_error_response_empty_error() {
+        let err = anyhow::anyhow!("");
+        let response = json_error_response(StatusCode::NOT_FOUND, err);
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+
+        let body_bytes = response.body();
+        let body_str = std::str::from_utf8(body_bytes).unwrap();
+        assert!(body_str.contains("\"error\":\"\""));
+    }
+
+}


### PR DESCRIPTION
@KokaKiwi  I have added a few unit tests to make sure we have a bit of coverage (about 75%), so that helpers don't mess up the components' coverage too much :) 

I've left the helpers code intact, only doing a tiny refactor to be able to test the main `TryFrom<IncomingRequest> for http::Request<IncomingBody>` logic.

Here's the coverage report:

```shell
Filename                      Regions    Missed Regions     Cover   Functions  Missed Functions  Executed       Lines      Missed Lines     Cover    Branches   Missed Branches     Cover
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
helpers/body.rs                   425                18    95.76%          46                 4    91.30%         224                11    95.09%           0                 0         -
helpers/extensions.rs             342               148    56.73%          24                14    41.67%         197                82    58.38%           0                 0         -
helpers/mod.rs                    140                65    53.57%           5                 1    80.00%          63                28    55.56%           0                 0         -
```

Note: I could not find a way to test some of the wit-bindgen stuff because it requires the `wasm32-wasip2` target (otherwise you hit some `unreachable!()` stuff).